### PR TITLE
Fix potential division by 0

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -149,7 +149,9 @@ function helpers.lighten(hex_color, amt)
 	-----------------------------
 	-- Saturation
 	local s
-	if l <= 0.5 then
+	if l == 0 then
+		s = 0
+	elseif l <= 0.5 then
 		s = c / (l * 2)
 	elseif l > 0.5 then
 		s = c / (2 - (l * 2))


### PR DESCRIPTION
Calling lighten with (#000000, 5) causes a division by 0 and subsequent errors